### PR TITLE
Parse subplugins.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ addons:
   postgresql: "9.4"
 
 services:
-- mysql
 - postgresql
 
 cache:
@@ -19,11 +18,9 @@ php:
 - 7.2
 
 env:
-  global:
-  - MOODLE_BRANCH=MOODLE_38_STABLE
   matrix:
-  #  - DB=pgsql
-  - DB=mysqli
+  - DB=pgsql MOODLE_BRANCH=MOODLE_37_STABLE
+  - DB=pgsql MOODLE_BRANCH=MOODLE_38_STABLE
 
 before_install:
 - phpenv config-rm xdebug.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,51 @@
+language: php
+
+sudo: true
+
+addons:
+  firefox: "47.0.1"
+  postgresql: "9.4"
+
+services:
+- mysql
+- postgresql
+
+cache:
+  directories:
+  - $HOME/.composer/cache
+  - $HOME/.npm
+
+php:
+- 7.2
+
+env:
+  global:
+  - MOODLE_BRANCH=MOODLE_38_STABLE
+  matrix:
+  #  - DB=pgsql
+  - DB=mysqli
+
+before_install:
+- phpenv config-rm xdebug.ini
+- nvm install 8.9
+- nvm use 8.9
+- touch cli/config.php # Phpunit tests expect this file to be present
+- cd ../..
+- composer create-project -n --no-dev --prefer-dist blackboard-open-source/moodle-plugin-ci ci ^2
+- export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
+
+install:
+- moodle-plugin-ci install
+
+script:
+- moodle-plugin-ci phplint
+#- moodle-plugin-ci phpcpd
+- moodle-plugin-ci phpmd
+#- moodle-plugin-ci codechecker
+#- moodle-plugin-ci validate
+- moodle-plugin-ci savepoints
+- moodle-plugin-ci mustache
+#- moodle-plugin-ci grunt
+#- moodle-plugin-ci phpdoc
+- moodle-plugin-ci phpunit
+- moodle-plugin-ci behat

--- a/classes/local/source_code.php
+++ b/classes/local/source_code.php
@@ -184,9 +184,17 @@ class source_code {
             }
         }
 
-        $subpluginsfile = $this->basepath.'/db/subplugins.php';
-        if (is_readable($subpluginsfile)) {
-            $subplugins = static::get_subplugins_from_file($subpluginsfile);
+        $subplugins = [];
+        $subpluginsfilejson = $this->basepath.'/db/subplugins.json';
+        if (is_readable($subpluginsfilejson)) {
+            $subplugins = (array) json_decode(file_get_contents($subpluginsfilejson))->plugintypes;
+        } else {
+            $subpluginsfile = $this->basepath.'/db/subplugins.php';
+            if (is_readable($subpluginsfile)) {
+                $subplugins = static::get_subplugins_from_file($subpluginsfile);
+            }
+        }
+        if ($subplugins) {
             $parentpath = static::plugin_type_relative_path($plugintype);
 
             foreach ($subplugins as $subplugintype => $subpluginpath) {

--- a/cli/config-dist.php
+++ b/cli/config-dist.php
@@ -55,7 +55,7 @@ define('AMOS_EXPORT_INSTALLER_DIR', $CFG->dataroot . '/amos/export-install');
  * S3 bucket where AMOS can write to
  * Does not have a default option as no default makes sense
  */
-define('AMOSS3BUCKET', '')
+define('AMOSS3BUCKET', '');
 
 /**
  * Full path to git

--- a/tests/external_api_test.php
+++ b/tests/external_api_test.php
@@ -46,7 +46,7 @@ class local_amos_external_api_testcase extends externallib_advanced_testcase {
         $user = self::getDataGenerator()->create_user();
         self::setUser($user);
 
-        $roleid = $this->assignUserCapability('local/amos:importstring', SYSCONTEXTID);
+        $roleid = $this->assignUserCapability('local/amos:importstrings', SYSCONTEXTID);
         $this->unassignUserCapability('local/amos:importstrings', SYSCONTEXTID, $roleid);
 
         $this->expectException(required_capability_exception::class);


### PR DESCRIPTION
In Moodle 3.8 subplugins can be defined in db/subplugins.json (instead of db/subplugins.php). See https://tracker.moodle.org/browse/MDL-65646

The unittests for parsing subplugins were present but looks like they were not running.
Also I added .travis.yml so we can run all unittests . I commented out the checks that are currently failing