### PR TITLE
Fix shows stash timemodified if exists

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -40,6 +40,8 @@ class local_amos_stash implements renderable {
     public $name;
     /** @var int timestamp of when the stash was created */
     public $timecreated;
+    /** @var int timestamp of when the stash was modified */
+    public $timemodified;
     /** @var stdClass the owner of the stash */
     public $owner;
     /** @var array of language names */
@@ -71,6 +73,7 @@ class local_amos_stash implements renderable {
         $new->id            = $stash->id;
         $new->name          = $stash->name;
         $new->timecreated   = $stash->timecreated;
+        $new->timemodified  = $stash->timemodified;
 
         $stage = new mlang_stage();
         $stash->apply($stage);
@@ -109,6 +112,7 @@ class local_amos_stash implements renderable {
         $new->id            = $record->id;
         $new->name          = $record->name;
         $new->timecreated   = $record->timecreated;
+        $new->timemodified  = $record->timemodified;
         $new->strings       = $record->strings;
         $new->components    = explode('/', trim($record->components, '/'));
         $new->languages     = explode('/', trim($record->languages, '/'));

--- a/renderer.php
+++ b/renderer.php
@@ -334,8 +334,14 @@ class local_amos_renderer extends plugin_renderer_base {
             'class' => 'my-2 mr-2 d-inline-block',
             'size' => 21,
         ]);
-        $output .= html_writer::tag('div', userdate($stash->timecreated, get_string('strftimedaydatetime', 'langconfig')),
-                                    ['class' => 'timecreated']);
+
+        if ($stash->timemodified) {
+            $output .= html_writer::tag('div', userdate($stash->timemodified, get_string('strftimedaydatetime', 'langconfig')),
+            ['class' => 'timemodified']);
+        } else {
+            $output .= html_writer::tag('div', userdate($stash->timecreated, get_string('strftimedaydatetime', 'langconfig')),
+            ['class' => 'timecreated']);
+        }
         $output .= html_writer::tag('div', get_string('stashstrings', 'local_amos', $stash->strings),
                                     ['class' => 'strings']);
         $output .= html_writer::tag('div', get_string('stashlanguages', 'local_amos', s(implode(', ', $stash->languages))),
@@ -372,8 +378,15 @@ class local_amos_renderer extends plugin_renderer_base {
         $output = '';
         $output .= $this->output->heading('#'.$contrib->info->id.' '.s($contrib->info->subject), 3, 'subject');
         $output .= $this->output->container($this->output->user_picture($contrib->author) . fullname($contrib->author), 'author');
-        $output .= $this->output->container(userdate($contrib->info->timecreated,
+
+        if ($contrib->info->timemodified) {
+            $output .= $this->output->container(userdate($contrib->info->timemodified,
+            get_string('strftimedaydatetime', 'langconfig')), 'timemodified');
+        } else {
+            $output .= $this->output->container(userdate($contrib->info->timecreated,
             get_string('strftimedaydatetime', 'langconfig')), 'timecreated');
+        }
+
         $output .= $this->output->container(format_text($contrib->info->message), 'message');
         $output = $this->box($output, 'generalbox source');
 

--- a/stash.php
+++ b/stash.php
@@ -95,8 +95,17 @@ if ($drop) {
     if (!$confirm) {
         $output = $PAGE->get_renderer('local_amos');
         echo $output->header();
+        $name = trim($stash->name);
+        if (empty($name)) {
+            // If name is empty, use the time of creation or modification.
+            $time = $stash->timemodified;
+            if (!$time) {
+                $time = $stash->timecreated;
+            }
+            $name = userdate($time, get_string('strftimedaydatetime', 'langconfig'));
+        }
         echo $output->confirm(
-            get_string('stashdropconfirm', 'local_amos', s($stash->name)),
+            get_string('stashdropconfirm', 'local_amos', s($name)),
             new moodle_url($PAGE->url, [
                 'confirm' => true,
                 'drop' => $drop,


### PR DESCRIPTION
This fix addresses issue MDLSITE-1357 by ensuring that the stash displays the timemodified only if it exists; otherwise, it defaults to showing timecreated.