### PR TITLE
MDLSITE-8170 Update AMOS import script paths to /public

### DIFF
--- a/cli/import-amos-strings.sh
+++ b/cli/import-amos-strings.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo -u www-data php /opt/app/local/amos/cli/import-strings.php --message='AMOS strings update' --versioncode=$(sudo -u www-data php /opt/app/admin/cli/cfg.php --name=branch) /opt/app/local/amos/lang/en/local_amos.php
+sudo -u www-data php /opt/app/public/local/amos/cli/import-strings.php --message='AMOS strings update' --versioncode=$(sudo -u www-data php /opt/app/admin/cli/cfg.php --name=branch) /opt/app/public/local/amos/lang/en/local_amos.php


### PR DESCRIPTION
Changed file paths in `import-amos-strings.sh` to follow Moodle 5.1 new structure